### PR TITLE
Introduced command line switch for custom delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ A complete help is available with the -h option:
                      Optional parameter for the GPIO RTS pin number
       -F [#]        RS-485 mode (/RTS on (0) when sending)
                      Optional parameter for the GPIO RTS pin number
+      -D #          /RTS delay in milliseconds (0.01 - 10000.0, disabled by default)
 
       -h            Print this help summary page
       -V            Print version and exit

--- a/mbpoll-config.h
+++ b/mbpoll-config.h
@@ -36,6 +36,8 @@ extern "C" {
 #define RTU_BAUDRATE_MAX  921600
 #define CHIPIO_SLAVEADDR_MIN 0x03
 #define CHIPIO_SLAVEADDR_MAX 0x77
+#define RTS_DELAY_MIN     0.01
+#define RTS_DELAY_MAX     10000.0
 
 /* default values =========================================================== */
 #define DEFAULT_MODE          eModeTcp

--- a/src/mbpoll.c
+++ b/src/mbpoll.c
@@ -183,6 +183,7 @@ static const char sRtuParityStr[] = "rtu parity";
 static const char sRtuStopbitsStr[] = "rtu stop bits";
 static const char sRtuDatabitsStr[] = "rtu data bits";
 static const char sRtuBaudrateStr[] = "rtu baudrate";
+static const char sRtuRtsDelay[] = "rtu rts delay";
 static const char sTcpPortStr[] = "tcp port";
 static const char sTimeoutStr[] = "timeout";
 static const char sPollRateStr[] = "poll rate";
@@ -272,7 +273,8 @@ static xMbPollContext ctx = {
     .dbits = DEFAULT_RTU_DATABITS,
     .sbits = DEFAULT_RTU_STOPBITS,
     .parity = DEFAULT_RTU_PARITY,
-    .flow = SERIAL_FLOW_NONE
+    .flow = SERIAL_FLOW_NONE,
+    .rtsDelay = -1
   },
   .bIsVerbose = false,
   .bIsPolling = true,
@@ -313,14 +315,14 @@ static xChipIoSerial * xChipSerial;
 static const char sChipIoSlaveAddrStr[] = "chipio slave address";
 static const char sChipIoIrqPinStr[] = "chipio irq pin";
 // option -i et -n supplémentaires pour chipio
-static const char * short_options = "m:a:r:c:t:1l:o:p:b:d:s:P:u0WRhVvwBqi:n:";
+static const char * short_options = "m:a:r:c:t:1l:o:p:b:d:s:P:D:u0WRhVvwBqi:n:";
 
 #else /* USE_CHIPIO == 0 */
 /* constants ================================================================ */
 #ifdef MBPOLL_GPIO_RTS
-static const char * short_options = "m:a:r:c:t:1l:o:p:b:d:s:P:u0WR::F::hVvwBq";
+static const char * short_options = "m:a:r:c:t:1l:o:p:b:d:s:P:D:u0WR::F::hVvwBq";
 #else
-static const char * short_options = "m:a:r:c:t:1l:o:p:b:d:s:P:u0WRFhVvwBq";
+static const char * short_options = "m:a:r:c:t:1l:o:p:b:d:s:P:D:u0WRFhVvwBq";
 #endif
 // -----------------------------------------------------------------------------
 #endif /* USE_CHIPIO == 0 */
@@ -548,6 +550,10 @@ main (int argc, char **argv) {
       case 'P':
         ctx.xRtu.parity = iGetEnum (sRtuParityStr, optarg, sParityList,
                                     iParityList, SIZEOF_ILIST (iParityList));
+        break;
+      case 'D':
+        ctx.xRtu.rtsDelay = dGetDouble (sRtuRtsDelay, optarg);
+        vCheckDoubleRange (sRtuRtsDelay, ctx.xRtu.rtsDelay, RTS_DELAY_MIN, RTS_DELAY_MAX);
         break;
 
 #ifdef USE_CHIPIO
@@ -812,14 +818,24 @@ main (int argc, char **argv) {
 
 #ifdef MBPOLL_GPIO_RTS
     if (ctx.iRtsPin >= 0) {
-      double t = 11 / (double) ctx.xRtu.baud / 2 * 1e6; // delay 1/2 car
+      double t = ctx.xRtu.rtsDelay;
+      if (t < 0) {
+        // delay 1/2 char by default
+        int pbits = ctx.xRtu.parity != SERIAL_PARITY_NONE ? 1 : 0;
+        t = (1 + ctx.xRtu.dbits + pbits + ctx.xRtu.sbits) / (double) ctx.xRtu.baud / 2 * 1e6; 
+      }
 
       if (init_custom_rts (ctx.iRtsPin, ctx.iRtuMode == MODBUS_RTU_RTS_UP) != 0) {
-
         vIoErrorExit ("Unable to set GPIO RTS pin: %d", ctx.iRtsPin);
       }
       modbus_rtu_set_custom_rts (ctx.xBus, set_custom_rts);
       modbus_rtu_set_rts_delay (ctx.xBus, (int) t);
+    } else {
+#endif
+      if (ctx.xRtu.rtsDelay > 0) {
+        modbus_rtu_set_rts_delay (ctx.xBus, (int) (ctx.xRtu.rtsDelay * 1000.0));
+      }
+#ifdef MBPOLL_GPIO_RTS
     }
 #endif
     modbus_rtu_set_serial_mode (ctx.xBus, MODBUS_RTU_RS485);

--- a/src/serial.h
+++ b/src/serial.h
@@ -78,6 +78,7 @@ typedef struct xSerialIos {
   eSerialParity parity; /**< Parité */
   eSerialStopBits sbits;/**< Bits de stop */
   eSerialFlow flow;/**< Contrôle de flux */
+  double rtsDelay; /**< Delay, in milliseconds, between the RTS enable signal and the data transmission */
   int flag; /**< Réservé pour un usage futur */
 } xSerialIos;
 


### PR DESCRIPTION
Hello,
This PR is to add a new command line switch to set a custom delay in the activation of the RTS line, even when the GPIO implementation is not used. This allow classic RS232 + RTS drive setup to use delays in the setups in which both the master and the slave node drive the line during a "space".
This is often used to avoid a floating bus and then spurious bits received by the nodes, when using a pull-up/pull-down is not an option. See `modbus_rtu_set_rts_delay` of `libmodbus`.

I'm not sure if you like the scale (milliseconds as decimal value, rather than seconds, or character count), the switch name. I even don't know if the documentation is correctly covered with this commit.

Thanks, L
  